### PR TITLE
Correct typo in family_home.html

### DIFF
--- a/xbrowse_server/templates/family/family_home.html
+++ b/xbrowse_server/templates/family/family_home.html
@@ -217,7 +217,7 @@
                             		    	Search in the Matchmaker Exchange
                            				</a>
 	                                    <br>
-	                                    <p>Search in the the Matchmaker Exchange federated network of centers to find other individuals with similar disorders.</p>
+	                                    <p>Search in the Matchmaker Exchange federated network of centers to find other individuals with similar disorders.</p>
                                     	{% if exported_to_matchmaker %}
 
                                     	<table><thead><th></th></thead>


### PR DESCRIPTION
Removed extra "the" from "Search in the the Matchmaker Exchange federated network of centers to find other individuals with similar disorders."